### PR TITLE
Let user specify fetch options - fix #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,21 @@ It supports GET and POST (direct and URL-encoded) query requests and basic authe
 
 ## Usage
 
-The module returns a function to build a middleware.
+The module exports a function to build a middleware.
 The function must be called with a single options object.
 The following options are supported:
 
 - `endpointUrl`: The URL of the SPARQL endpoint
 - `authentication`: Credentials for basic authentication (object with `user` and `password` property)
 - `queryOperation`: The query operation which will be used to access the SPARQL endpoint (default: `postQueryDirect`)
+- `fetchOptions`: an object that will be merged (and potentially override) with
+  [node-fetch options](https://github.com/bitinn/node-fetch/blob/bf8b4e8db350ec76dbb9236620f774fcc21b8c12/README.md#options) used for the request from the proxy to the SPARQL endpoint. It can be used to override fetch headers: `fetchOptions.headers`
 
 ## Example
 
-```
+```js
 // load the module
-var sparqlProxy = require('sparql-proxy')
+const sparqlProxy = require('sparql-proxy')
 
 // create a middleware instance and add it to the routing
 app.use(sparqlProxy({

--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ function authBasicHeader (user, password) {
 function sparqlProxy (options) {
   const queryOptions = {}
 
+  if (options.fetchOptions) {
+    Object.assign(queryOptions, options.fetchOptions)
+  }
+
   if (options.authentication) {
     queryOptions.headers = {
       Authorization: authBasicHeader(options.authentication.user, options.authentication.password)


### PR DESCRIPTION
Here's a fix for #1

Passing your own http.Agent and a custom header: 
```js
sparqlProxy({
  endpointUrl: 'http://example.org/query',
  fetchOptions: {
    agent: customAgent,
    headers: { 'User-Agent': 'custom user agent' }
  }
})
```