### PR TITLE
Better debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ app.use(sparqlProxy({
   endpointUrl: 'https://dbpedia.org/sparql'
 })
 ```
+
+## Debug
+
+This package uses [`debug`](https://www.npmjs.com/package/debug), you can get debug logging via: `DEBUG=sparql-proxy`.  
+Since [Trifid](https://github.com/zazuko/trifid) makes heavy use of this package, using `DEBUG=trifid:*` also enables
+logging in this package.

--- a/index.js
+++ b/index.js
@@ -1,11 +1,16 @@
 const bodyParser = require('body-parser')
 const cloneDeep = require('lodash/cloneDeep')
+const debug = require('debug')
 const defaults = require('lodash/defaults')
 const fetch = require('node-fetch')
 const Router = require('express').Router
 const SparqlHttpClient = require('sparql-http-client')
-
 SparqlHttpClient.fetch = fetch
+
+if (debug.enabled('trifid:*')) {
+  debug.enable('sparql-proxy')
+}
+const logger = debug('sparql-proxy')
 
 function authBasicHeader (user, password) {
   return 'Basic ' + Buffer.from(user + ':' + password).toString('base64')
@@ -35,11 +40,11 @@ function sparqlProxy (options) {
       return
     }
 
-    console.log('handle SPARQL request for endpoint: ' + options.endpointUrl)
+    logger('handle SPARQL request for endpoint: ' + options.endpointUrl)
     if (query) {
-      console.log('SPARQL query:' + query)
+      logger('SPARQL query:' + query)
     } else {
-      console.log('No SPARQL query; issuing a GET')
+      logger('No SPARQL query; issuing a GET')
       queryOperation = 'getQuery'
     }
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "body-parser": "^1.17.2",
+    "debug": "^4.1.1",
     "express": "^4.15.4",
     "lodash": "^4.16.4",
     "node-fetch": "^2.5.0",


### PR DESCRIPTION
> ## Debug
> 
>  This package uses [`debug`](https://www.npmjs.com/package/debug), you can get debug logging via: `DEBUG=sparql-proxy`.  
> Since [Trifid](https://github.com/zazuko/trifid) makes heavy use of this package, using `DEBUG=trifid:*` also enables
> logging in this package.