### PR TITLE
Do not override all debug namespaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,10 @@ const SparqlHttpClient = require('sparql-http-client')
 SparqlHttpClient.fetch = fetch
 
 if (debug.enabled('trifid:*')) {
-  debug.enable('sparql-proxy')
+  const enabled = debug.disable()
+  debug.enable(`${enabled},sparql-proxy`)
 }
+
 const logger = debug('sparql-proxy')
 
 function authBasicHeader (user, password) {


### PR DESCRIPTION
I got it wrong from `debug`'s documentation: `debug.enable()` replaces all namespaces. This means that if you had a package with `trifid:something` and used `trifid:*`, `trifid:something` would print until it enters this package which would enable `sparql-proxy` instead. What we wanted here was to enable `sparql-proxy` in addition to already enabled namespaces.

The only way of getting all namespaces is to use `debug.disable()`: with this PR we retrieve all enabled namespaces and do exactly what I described.