### PR TITLE
Fix empty query

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function sparqlProxy (options) {
     let query
 
     if (req.method === 'GET') {
-      query = req.query.query || ''
+      query = req.query.query
     } else if (req.method === 'POST') {
       query = req.body.query || req.body
     } else {

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
   "dependencies": {
     "body-parser": "^1.17.2",
     "debug": "^4.1.1",
-    "express": "^4.15.4",
+    "express": "^4.17.0",
     "lodash": "^4.16.4",
-    "node-fetch": "^2.5.0",
-    "sparql-http-client": "^1.0.1"
+    "node-fetch": "^2.6.0",
+    "sparql-http-client": "^1.1.0"
   },
   "devDependencies": {
     "mocha": "^6.1.4",

--- a/test/sparql-proxy.js
+++ b/test/sparql-proxy.js
@@ -62,7 +62,7 @@ describe('sparql-proxy', () => {
       endpointUrl: 'http://example.org/get/query'
     }))
 
-    nock('http://example.org').get('/get/query?query=').reply(200, () => 'Nothing')
+    nock('http://example.org').get('/get/query').reply(200, () => 'Nothing')
 
     const res = await request(app)
       .get('/query')


### PR DESCRIPTION
Related to https://github.com/zazuko/trifid/issues/45 and https://github.com/zazukoians/sparql-http-client/pull/3

The value of `param.query` should not be `''` in both `/path` and `/path?query=`, it should be `undefined` in the first case and `''` only in the 2nd case.

This will make it possible for `sparql-http-client` to decide whether to use a `?query` param on the sparql endpoint or not.

Tests should be fixed by merging the sparql-http-client, releasing it and updating it here.