### PR TITLE
Cache: add support for Redis

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "standard"
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "express": "^4.18.2",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.7",
+    "redis": "^4.5.1",
     "sparql-http-client": "^1.2.0"
   },
   "devDependencies": {

--- a/test/sparql-proxy.js
+++ b/test/sparql-proxy.js
@@ -228,4 +228,27 @@ describe('sparql-proxy', () => {
       .get('/query?query=' + encodeURIComponent(query))
       .expect(502)
   })
+
+  it('should not crash even if redis is not recheable', async () => {
+    const app = express()
+
+    app.use('/query', sparqlProxy({
+      endpointUrl: 'http://example.org/post-url-encoded/query',
+      cache: {
+        url: 'redis://user:password@unknown.redis.localhost:6380'
+      }
+    }))
+
+    nock('http://example.org').post('/post-url-encoded/query').reply(200, (uri, body) => body)
+
+    const backupConsoleError = console.error
+    console.error = (..._args) => { }
+    const res = await request(app)
+      .post('/query')
+      .set('content-type', 'application/x-www-form-urlencoded')
+      .send('query=' + encodeURIComponent(query))
+      .expect(200)
+    console.error = backupConsoleError
+    assert.strictEqual(res.text, query)
+  })
 })


### PR DESCRIPTION
To improve performances, a Redis instance can be configured to store answers from the triple store. That way, responses are sent a lot faster to the end user.